### PR TITLE
Typo

### DIFF
--- a/statefulset-services/redis-headless.yaml
+++ b/statefulset-services/redis-headless.yaml
@@ -1,4 +1,4 @@
-piVersion: v1
+apiVersion: v1
 kind: Service
 metadata:
   name: redis-service


### PR DESCRIPTION
This is a single word typo that will abort the  kubeadm command with a warning unless the warning is suppressed.